### PR TITLE
Preinstall shim-signed shim

### DIFF
--- a/etc/config/package-lists.calamares/desktop.list.chroot_live
+++ b/etc/config/package-lists.calamares/desktop.list.chroot_live
@@ -9,6 +9,8 @@ calamares-settings-cinnamon-remix
 xfsprogs
 jfsutils
 reiserfsprogs
+shim-signed
+shim
 ntfs-3g
 lvm2
 dmraid


### PR DESCRIPTION
Fix for installation issue in Secure Boot enabled machines with Calamares.